### PR TITLE
Removing the master/slave phrasing

### DIFF
--- a/modules/kiss_expand.py
+++ b/modules/kiss_expand.py
@@ -383,18 +383,18 @@ class PIIO(object):
 
 class RADIO(object):
     '''
-    If you have a NRF24L01+ or HM-TRLR-S transceiver connected to this device you can use server/client or master/slave functionality.
+    If you have a NRF24L01+ or HM-TRLR-S transceiver connected to this device you can use server/client or main/subordinate functionality.
     NRF24L01+
         Enable the nrf24 server functionality in command line: set-flag  nrf24_server
         On client device: set-flag  nrf24_client
-        Master: set-flag  nrf24_master
-        Slave: set-flag  nrf24_slave
+        Main: set-flag  nrf24_main
+        Subordinate: set-flag  nrf24_subordinate
         Must restart the steelsquid daeomon for it to take effect.
         In python you can do: steelsquid_kiss_global.nrf24_status(status)
         status: server=Enable as server
                 client=Enable as client
-                master=Enable as master
-                slave=Enable as slave
+                main=Enable as main
+                subordinate=Enable as subordinate
                 None=Disable
         SERVER/CLIENT:
         If the clent execute: data = steelsquid_nrf24.request("a_command", data)
@@ -402,22 +402,22 @@ class RADIO(object):
         The server then can return some data that the client will reseive...
         If server method raise exception the steelsquid_nrf24.request("a_command", data) will also raise a exception.
         MASTER/SLAVE:
-        One of the devices is master and can send data to the slave (example a file or video stream).
+        One of the devices is main and can send data to the subordinate (example a file or video stream).
         The data is cut up into packages and transmitted.
-        The slave can transmitt short command back to the master on every package of data it get.
-        This is usefull if you want to send a low resolution and low framerate video from the master to the slave.
-        And the slave then can send command back to the master.
-        Master execute: steelsquid_nrf24.send(data)
+        The subordinate can transmitt short command back to the main on every package of data it get.
+        This is usefull if you want to send a low resolution and low framerate video from the main to the subordinate.
+        And the subordinate then can send command back to the main.
+        Main execute: steelsquid_nrf24.send(data)
         The method: on_receive(data) will be called on the client
-        Slave execute: steelsquid_nrf24.command("a_command", parameters)
-        A method with the name: a_command(parameters) will be called on the master
+        Subordinate execute: steelsquid_nrf24.command("a_command", parameters)
+        A method with the name: a_command(parameters) will be called on the main
                                 parameters is a list of strings
     '''
 
     @staticmethod
     def on_receive(data):
         '''
-        Data from the master to the slave
+        Data from the main to the subordinate
         '''
         pass
 

--- a/steelsquid_kiss_boot.py
+++ b/steelsquid_kiss_boot.py
@@ -581,7 +581,7 @@ def _cleanup():
             steelsquid_utils.execute_system_command_blind(["sync"], wait_for_finish=True)
         except:
             steelsquid_utils.shout()
-        if steelsquid_utils.get_flag("nrf24_master") or steelsquid_utils.get_flag("nrf24_slave"):
+        if steelsquid_utils.get_flag("nrf24_main") or steelsquid_utils.get_flag("nrf24_subordinate"):
             try:
                 steelsquid_nrf24.stop()
             except:
@@ -831,14 +831,14 @@ def nrf24_server_thread():
                 steelsquid_utils.shout()
 
 
-def nrf24_slave_thread():
+def nrf24_subordinate_thread():
     '''
-    Start slave thread for the NRF24L01 radio transiver
-    listen for data from the master and execute method in RADIO class
+    Start subordinate thread for the NRF24L01 radio transiver
+    listen for data from the main and execute method in RADIO class
     '''
     while running:
         try:
-            # Listen for data from master
+            # Listen for data from main
             data = steelsquid_nrf24.receive(timeout=2)
             if data!=None:
                 # Execute method on_receive in module RADIO class
@@ -849,7 +849,7 @@ def nrf24_slave_thread():
 
 def nrf24_callback(command):
     '''
-    Master get a command from the slave
+    Main get a command from the subordinate
     '''
     try:
         # Execute method on_receive in module RADIO class
@@ -1590,15 +1590,15 @@ def main():
                 elif steelsquid_utils.get_flag("nrf24_client"):
                     steelsquid_utils.shout("Enable NRF24L01+ client")
                     steelsquid_nrf24.client()
-                # Enable NRF24L01+ as master
-                if steelsquid_utils.get_flag("nrf24_master"):
-                    steelsquid_utils.shout("Enable NRF24L01+ master")
-                    steelsquid_nrf24.master(nrf24_callback)
-                # Enable NRF24L01+ as slave
-                elif steelsquid_utils.get_flag("nrf24_slave"):
-                    steelsquid_utils.shout("Enable NRF24L01+ slave")
-                    steelsquid_nrf24.slave()
-                    thread.start_new_thread(nrf24_slave_thread, ())
+                # Enable NRF24L01+ as main
+                if steelsquid_utils.get_flag("nrf24_main"):
+                    steelsquid_utils.shout("Enable NRF24L01+ main")
+                    steelsquid_nrf24.main(nrf24_callback)
+                # Enable NRF24L01+ as subordinate
+                elif steelsquid_utils.get_flag("nrf24_subordinate"):
+                    steelsquid_utils.shout("Enable NRF24L01+ subordinate")
+                    steelsquid_nrf24.subordinate()
+                    thread.start_new_thread(nrf24_subordinate_thread, ())
                 # Enable HM-TRLR-S as server (the new functionality)
                 if steelsquid_utils.get_flag("radio_hmtrlrs_server"):
                     config_gpio = int(steelsquid_utils.get_parameter("hmtrlrs_config_gpio", "25"))

--- a/steelsquid_kiss_global.py
+++ b/steelsquid_kiss_global.py
@@ -573,35 +573,35 @@ def nrf24_status(status):
     Must reboot to implement
     status: server=Enable as server
             client=Enable as client
-            master=Enable as master
-            slave=Enable as slave
+            main=Enable as main
+            subordinate=Enable as subordinate
             None=Disable
     '''    
     if status==None:
         steelsquid_utils.del_flag("nrf24_server")
         steelsquid_utils.del_flag("nrf24_client")
-        steelsquid_utils.del_flag("nrf24_master")
-        steelsquid_utils.del_flag("nrf24_slave")
+        steelsquid_utils.del_flag("nrf24_main")
+        steelsquid_utils.del_flag("nrf24_subordinate")
     elif status=="server":
         steelsquid_utils.set_flag("nrf24_server")
         steelsquid_utils.del_flag("nrf24_client")
-        steelsquid_utils.del_flag("nrf24_master")
-        steelsquid_utils.del_flag("nrf24_slave")
+        steelsquid_utils.del_flag("nrf24_main")
+        steelsquid_utils.del_flag("nrf24_subordinate")
     elif status=="client":
         steelsquid_utils.del_flag("nrf24_server")
         steelsquid_utils.set_flag("nrf24_client")
-        steelsquid_utils.del_flag("nrf24_master")
-        steelsquid_utils.del_flag("nrf24_slave")
-    elif status=="master":
+        steelsquid_utils.del_flag("nrf24_main")
+        steelsquid_utils.del_flag("nrf24_subordinate")
+    elif status=="main":
         steelsquid_utils.del_flag("nrf24_server")
         steelsquid_utils.del_flag("nrf24_client")
-        steelsquid_utils.set_flag("nrf24_master")
-        steelsquid_utils.del_flag("nrf24_slave")
-    elif status=="slave":
+        steelsquid_utils.set_flag("nrf24_main")
+        steelsquid_utils.del_flag("nrf24_subordinate")
+    elif status=="subordinate":
         steelsquid_utils.del_flag("nrf24_server")
         steelsquid_utils.del_flag("nrf24_client")
-        steelsquid_utils.del_flag("nrf24_master")
-        steelsquid_utils.set_flag("nrf24_slave")
+        steelsquid_utils.del_flag("nrf24_main")
+        steelsquid_utils.set_flag("nrf24_subordinate")
     
 
 def _broadcast_event_handler():

--- a/steelsquid_trex.py
+++ b/steelsquid_trex.py
@@ -15,7 +15,7 @@ smbus to send command
 quick2wire to read status
 I can not get both functions operate on one of the librarys.
 Smbus can not read multipple bytes from the bus without sending a register command.
-And I did not get quick2wire to work when write to the slave.
+And I did not get quick2wire to work when write to the subordinate.
 
 Dependencies
 ------------
@@ -86,7 +86,7 @@ def __trex_reset():
     trex_package[21] = 50  # Impact sensitivity low byte
     trex_package[22] = 2   # Battery voltage high byte
     trex_package[23] = 38  # Battery voltage low byte
-    trex_package[24] = 7   # I2C slave address
+    trex_package[24] = 7   # I2C subordinate address
     trex_package[25] = 0   # I2C clock frequency
 
 __trex_reset()


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.